### PR TITLE
Add kitty quake style dropdown terminal

### DIFF
--- a/modules/darwin/yabai.nix
+++ b/modules/darwin/yabai.nix
@@ -28,6 +28,7 @@ in {
 
         yabai -m rule --add app="^kitty$" border=off
         yabai -m rule --add app="^kitty$" title="${pkgs.kitty}/bin/kitty"
+        yabai -m rule --add app="^kitty$" title="quake" manage=off
       '';
     };
     skhd = {
@@ -84,6 +85,9 @@ in {
         # Launch kitty terminal (using nix-installed kitty)
         cmd - return : ${pkgs.kitty}/bin/kitty --single-instance --directory="$HOME"
 
+        # Toggle quake style dropdown terminal
+        cmd + shift - return : ${pkgs.kitty}/bin/kitty --single-instance --title "quake" --config "quake"
+        
         # Restart yabai
         ctrl + alt + cmd - r : launchctl kickstart -k "org.nixos.yabai"
       '';

--- a/modules/home/shared/kitty.nix
+++ b/modules/home/shared/kitty.nix
@@ -83,6 +83,22 @@
       allow_remote_control = "yes";
       listen_on = "unix:/tmp/kitty";
       shell_integration = "enabled";
+
+      # Quake style dropdown terminal settings
+      quake = {
+        window_type = "desktop";
+        window_padding_width = "0";
+        window_margin_width = "0";
+        window_border_width = "0";
+        window_opacity = 0.95;
+        window_height = "50%";
+        window_width = "100%";
+        window_position = "top";
+      };
+    };
+    keybindings = {
+      "ctrl+shift+space" = "toggle_window";
+      "cmd+shift+return" = "kitty --single-instance --title 'quake' --config 'quake'";
     };
     extraConfig = ''
       # GENERATED


### PR DESCRIPTION
Fixes #2

Add configuration for a kitty quake style dropdown terminal.

* **modules/home/shared/kitty.nix**
  - Add `quake` configuration to `programs.kitty.settings` with specific settings for a quake style dropdown terminal.
  - Add keybindings for toggling the quake style dropdown terminal and launching it with specific settings.
* **modules/darwin/yabai.nix**
  - Add a new rule to `extraConfig` for kitty to support the quake style dropdown terminal.
  - Add a new keybinding to `skhdConfig` to toggle the quake style dropdown terminal.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alkimake/nixconfig/pull/3?shareId=dd251d72-512b-4a9f-8c84-103ab0a11c92).